### PR TITLE
Refactor axios base URL configuration in AuthContext and api services

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
 // Set the base URL for all axios requests
-axios.defaults.baseURL = import.meta.env.VITE_API_URL || 'http://localhost:3002';
+axios.defaults.baseURL = import.meta.env.VITE_API_URL;
 axios.defaults.withCredentials = true;
 
 // Create the context

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // Set base URL from environment variable
-axios.defaults.baseURL = import.meta.env.VITE_API_URL || 'http://localhost:3002';
+axios.defaults.baseURL = import.meta.env.VITE_API_URL ;
 axios.defaults.withCredentials = true; // Important for sending cookies
 
 // Request interceptor to handle errors


### PR DESCRIPTION
- Updated axios base URL in AuthContext.jsx and api.js to use only the environment variable VITE_API_URL, removing the fallback to localhost. This ensures consistency in API requests across the application.